### PR TITLE
Added default option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,44 @@ class UserSerializer < EasySerializer::Base
 end
 ```
 
+**Using defaults:**
+
+Default will only be triggered when value is [nil]
+
+```ruby
+obj = OpenStruct.new(name: 'Jack', boolean: nil, missing: nil)
+
+class DefaultLiteral < EasySerializer::Base
+  attribute :name
+  attribute :boolean, default: true
+  attribute(:missing, default: 'anything') { |obj| obj.missing }
+end
+
+output = DefaultLiteral.call(obj)
+output.fetch(:name) #=> 'Jack'
+output.fetch(:boolean) #=> true
+output.fetch(:missing) #=> 'anything'
+```
+
+Using blocks:
+
+```ruby
+obj = OpenStruct.new(name: 'Jack', boolean: nil, missing: nil)
+
+class DefaultBlock < EasySerializer::Base
+  attribute :name
+  attribute :boolean, default: proc { |obj| obj.name == 'Jack' }
+  attribute :missing, default: proc { |obj| "#{obj.name}-missing" } do |obj|
+    obj.missing
+  end
+end
+
+output = DefaultBlock.call(obj)
+output.fetch(:name) #=> 'Jack'
+output.fetch(:boolean) #=> true
+output.fetch(:missing) #=> 'Jack-missing'
+```
+
 ### Serializing nested objects
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 [![Test Coverage](https://codeclimate.com/github/arturictus/easy_serializer/badges/coverage.svg)](https://codeclimate.com/github/arturictus/easy_serializer/coverage)
 
 Semantic serializer for making easy serializing objects.
+EasySerializer is inspired in [ActiveModel Serializer > 0.10] (https://github.com/rails-api/active_model_serializers/tree/v0.10.0.rc3) it's a
+simple solution for a day to day work with APIs.
+It tries to give you a serializer with flexibility, full of features and important capabilities for caching.
 
-features:
+Features:
 - Nice and simple serialization DSL.
 - Cache helpers to use with your favorite adapter like rails cache.
 
@@ -112,7 +115,7 @@ end
 
 **Using defaults:**
 
-Default will only be triggered when value is [nil]
+Default will only be triggered when value is `nil`
 
 ```ruby
 obj = OpenStruct.new(name: 'Jack', boolean: nil, missing: nil)

--- a/easy_serializer.gemspec
+++ b/easy_serializer.gemspec
@@ -10,7 +10,9 @@ Gem::Specification.new do |spec|
   spec.email         = ["arturictus@gmail.com"]
 
   spec.summary       = %q{Semantic serializer for making easy serializing objects.}
-  spec.description   = %q{Semantic serializer for making easy serializing objects.}
+  spec.description   = %q{EasySerializer is inspired in ActiveModel Serializer > 0.10 it's a
+  simple solution for a day to day work with APIs.
+  It tries to give you a serializer with flexibility, full of features and important capabilities for caching.}
   spec.homepage      = "https://github.com/arturictus/easy_serializer"
   spec.license       = "MIT"
 

--- a/lib/easy_serializer/base.rb
+++ b/lib/easy_serializer/base.rb
@@ -52,10 +52,10 @@ module EasySerializer
     def _serialize
       __serializable_attributes.each_with_object(HashWithIndifferentAccess.new) do |setup, hash|
         if setup[:key] === false
-          hash.merge!(attr_serializer(setup))
+          hash.merge!(value_or_default(setup))
         else
           key = (setup[:key] ? setup[:key] : setup[:name])
-          hash[key] = attr_serializer(setup)
+          hash[key] = value_or_default(setup)
         end
       end
     end
@@ -73,6 +73,14 @@ module EasySerializer
 
     def __serializable_attributes
       self.class.instance_variable_get(:@__serializable_attributes) || []
+    end
+
+    def value_or_default(setup)
+      value = attr_serializer(setup)
+      if value.nil? && setup[:default]
+        return option_to_value(setup[:default], object)
+      end
+      value
     end
 
     def attr_serializer(setup)

--- a/spec/base/default_spec.rb
+++ b/spec/base/default_spec.rb
@@ -1,0 +1,96 @@
+describe 'default values when nil' do
+  context 'As a literal' do
+    class DefaultLiteral < EasySerializer::Base
+      attribute :name
+      attribute :boolean, default: true
+      attribute :missing, default: 'anything'
+    end
+    let(:execute) { DefaultLiteral.call(obj) }
+    context 'nil values' do
+      let(:obj) { OpenStruct.new(name: 'Jack', boolean: nil, missing: nil) }
+      it { expect(execute.fetch(:name)).to eq 'Jack' }
+      it { expect(execute.fetch(:boolean)).to eq true }
+      it { expect(execute.fetch(:missing)).to eq 'anything' }
+    end
+    context 'With values' do
+      let(:obj) { OpenStruct.new(name: 'Jack', boolean: false, missing: 'blabla') }
+      it { expect(execute.fetch(:name)).to eq 'Jack' }
+      it { expect(execute.fetch(:boolean)).to eq false }
+      it { expect(execute.fetch(:missing)).to eq 'blabla' }
+    end
+  end
+  context 'As a Proc' do
+    class DefaultProc < EasySerializer::Base
+      attribute :name
+      attribute :boolean, default: proc { |obj| obj.name == 'Jack' }
+      attribute :missing, default: proc { |obj| "#{obj.name}-missing" }
+    end
+
+    let(:execute) { DefaultProc.call(obj) }
+
+    context 'nil values' do
+      let(:obj) { OpenStruct.new(name: 'Jack', boolean: nil, missing: nil) }
+      it { expect(execute.fetch(:name)).to eq 'Jack' }
+      it { expect(execute.fetch(:boolean)).to eq true }
+      it { expect(execute.fetch(:missing)).to eq 'Jack-missing' }
+    end
+    context 'With values' do
+      let(:obj) { OpenStruct.new(name: 'Jack', boolean: false, missing: 'blabla') }
+      it { expect(execute.fetch(:name)).to eq 'Jack' }
+      it { expect(execute.fetch(:boolean)).to eq false }
+      it { expect(execute.fetch(:missing)).to eq 'blabla' }
+    end
+  end
+  context 'When blocks are the value output' do
+    context 'As Proc' do
+      class DefaultWithBlockProc < EasySerializer::Base
+        attribute :name
+        attribute :boolean, default: proc { |obj| obj.name == 'Jack' } do |obj|
+          obj.boolean
+        end
+        attribute :missing, default: proc { |obj| "#{obj.name}-missing" } do |obj|
+          obj.missing
+        end
+      end
+
+      let(:execute) { DefaultWithBlockProc.call(obj) }
+
+      context 'nil values' do
+        let(:obj) { OpenStruct.new(name: 'Jack', boolean: nil, missing: nil) }
+        it { expect(execute.fetch(:name)).to eq 'Jack' }
+        it { expect(execute.fetch(:boolean)).to eq true }
+        it { expect(execute.fetch(:missing)).to eq 'Jack-missing' }
+      end
+      context 'With values' do
+        let(:obj) { OpenStruct.new(name: 'Jack', boolean: false, missing: 'blabla') }
+        it { expect(execute.fetch(:name)).to eq 'Jack' }
+        it { expect(execute.fetch(:boolean)).to eq false }
+        it { expect(execute.fetch(:missing)).to eq 'blabla' }
+      end
+    end
+    context 'As a literal' do
+      class DefaultBlockLiteral < EasySerializer::Base
+        attribute :name
+        attribute :boolean, default: true do |obj|
+          obj.boolean
+        end
+        attribute :missing, default: 'anything' do |obj|
+          obj.missing
+        end
+      end
+      let(:execute) { DefaultBlockLiteral.call(obj) }
+      context 'nil values' do
+        let(:obj) { OpenStruct.new(name: 'Jack', boolean: nil, missing: nil) }
+        it { expect(execute.fetch(:name)).to eq 'Jack' }
+        it { expect(execute.fetch(:boolean)).to eq true }
+        it { expect(execute.fetch(:missing)).to eq 'anything' }
+      end
+      context 'With values' do
+        let(:obj) { OpenStruct.new(name: 'Jack', boolean: false, missing: 'blabla') }
+        it { expect(execute.fetch(:name)).to eq 'Jack' }
+        it { expect(execute.fetch(:boolean)).to eq false }
+        it { expect(execute.fetch(:missing)).to eq 'blabla' }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Default option for attributes:

Default will only be triggered when value is `nil`

```ruby
obj = OpenStruct.new(name: 'Jack', boolean: nil, missing: nil)

class DefaultLiteral < EasySerializer::Base
  attribute :name
  attribute :boolean, default: true
  attribute(:missing, default: 'anything') { |obj| obj.missing }
end

output = DefaultLiteral.call(obj)
output.fetch(:name) #=> 'Jack'
output.fetch(:boolean) #=> true
output.fetch(:missing) #=> 'anything'
```

Using blocks:

```ruby
obj = OpenStruct.new(name: 'Jack', boolean: nil, missing: nil)

class DefaultBlock < EasySerializer::Base
  attribute :name
  attribute :boolean, default: proc { |obj| obj.name == 'Jack' }
  attribute :missing, default: proc { |obj| "#{obj.name}-missing" } do |obj|
    obj.missing
  end
end

output = DefaultBlock.call(obj)
output.fetch(:name) #=> 'Jack'
output.fetch(:boolean) #=> true
output.fetch(:missing) #=> 'Jack-missing'
```
